### PR TITLE
Remove extensions from page URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,5 @@ plugins:
 
 title: Tyler Kindy
 tagline: My personal site
+
+permalink: /:categories/:year/:month/:day/:title

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,3 @@ title: Tyler Kindy
 tagline: My personal site
 
 permalink: /:categories/:year/:month/:day/:title
-
-include:
-  - _redirects

--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,6 @@ title: Tyler Kindy
 tagline: My personal site
 
 permalink: /:categories/:year/:month/:day/:title
+
+include:
+  - _redirects

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,4 +1,4 @@
 - name: Home
   link: /
 - name: Blog
-  link: /blog.html
+  link: /blog

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,0 @@
-/blog.html /blog
-/2020/05/26/jekyll-serve-mobile.html /2020/05/26/jekyll-serve-mobile
-/2020/05/25/flexbox-ios.html /2020/05/25/flexbox-ios

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+/blog.html /blog
+/2020/05/26/jekyll-serve-mobile.html /2020/05/26/jekyll-serve-mobile
+/2020/05/25/flexbox-ios.html /2020/05/25/flexbox-ios


### PR DESCRIPTION
I noticed my pages ended with `.html` which felt ugly to me. This PR cleans those up, ~as well as adds redirects (using Netlify's `_redirects` file) to point the old URLs at the new URLs.~